### PR TITLE
Don't forward OPTIONS requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,9 @@ async function service (req, res) {
     // Don't waste my precious bandwidth
     return send(res, 403, '')
   }
+  if (req.method === 'OPTIONS') {
+    return send(res, 200, '')
+  }
 
   let headers = {}
   for (let h of allowHeaders) {

--- a/micro-cors.js
+++ b/micro-cors.js
@@ -20,43 +20,27 @@ const DEFAULT_ALLOW_HEADERS = [
 
 const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 // 24 hours
 
-const cors = options => handler => (req, res, ...restArgs) => {
+const cors = (options = {}) => handler => (req, res, ...restArgs) => {
   const {
-    maxAge,
-    origin,
-    allowHeaders,
-    exposeHeaders,
-    allowMethods
-  } = (options || {})
+    origin = '*',
+    maxAge = DEFAULT_MAX_AGE_SECONDS,
+    allowMethods = DEFAULT_ALLOW_METHODS,
+    allowHeaders = DEFAULT_ALLOW_HEADERS,
+    exposeHeaders = []
+  } = options
 
-  res.setHeader(
-    'Access-Control-Max-Age',
-    '' + (maxAge || DEFAULT_MAX_AGE_SECONDS)
-  )
-
-  res.setHeader(
-    'Access-Control-Allow-Origin',
-    (origin || '*')
-  )
-
-  res.setHeader(
-    'Access-Control-Allow-Methods',
-    (allowMethods || DEFAULT_ALLOW_METHODS).join(',')
-  )
-
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    (allowHeaders || DEFAULT_ALLOW_HEADERS).join(',')
-  )
-
-  if (exposeHeaders && exposeHeaders.length) {
-    res.setHeader(
-      'Access-Control-Expose-Headers',
-      exposeHeaders.join(',')
-    )
+  res.setHeader('Access-Control-Allow-Origin', origin)
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+  if (exposeHeaders.length) {
+    res.setHeader('Access-Control-Expose-Headers', exposeHeaders.join(','))
   }
 
-  res.setHeader('Access-Control-Allow-Credentials', 'true')
+  const preFlight = req.method === 'OPTIONS'
+  if (preFlight) {
+    res.setHeader('Access-Control-Allow-Methods', allowMethods.join(','))
+    res.setHeader('Access-Control-Allow-Headers', allowHeaders.join(','))
+    res.setHeader('Access-Control-Max-Age', String(maxAge))
+  }
 
   return handler(req, res, ...restArgs)
 }


### PR DESCRIPTION
Github send a 405 status `Method Not Allowed` for OPTIONS request.
So if the browser send a Preflight request (When you use the proxy of a different origin than isomorphic-git.org) the request will fail

To work around this if the status is not in success range (200-299) we don't set the status (I guess micro sets it to 200 by default the) so the OPTIONS request could not fail :smile: 