### PR TITLE
Add instructions for k8s deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,16 @@ There is no official chart for this project, helm or otherwise. You can make you
 _Example:_
 ```yaml
   containers:
-      - command:
+      - name: cors-proxy
+        image: node:lts-alpine
+        env:
+        - name: ALLOW_ORIGIN
+          value: https://mydomain.com
+        command:
         - npx
         args:
         - '@isomorphic-git/cors-proxy'
         - start
-        image: node:lts-alpine
-        name: cors-proxy
         ports:
         - containerPort: 9999
           hostPort: 9999

--- a/README.md
+++ b/README.md
@@ -106,6 +106,33 @@ function getAuthorizedUser(req: Request, header: string = 'Authorization') {
 }
 ```
 
+## Installation on Kubernetes
+
+There is no official chart for this project, helm or otherwise. You can make your own, but keep in mind cors-proxy uses the Micro server, which will return a 403 error for any requests that do not have the user agent header.
+
+_Example:_
+```yaml
+  containers:
+      - command:
+        - npx
+        args:
+        - '@isomorphic-git/cors-proxy'
+        - start
+        image: node:lts-alpine
+        name: cors-proxy
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+          name: proxy
+          protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: proxy
+        readinessProbe:
+          tcpSocket:
+            port: proxy
+```
+
 ## License
 
 This work is released under [The MIT License](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
There are quite a few pitfalls that make deployment on k8s less than trivial. Micro requires headers and crashes NPX when you try to bypass the installation confirmation with `-y` or `--yes` on official node container images.