### PR TITLE
Do not crash with `getaddrinfo ENOTFOUND`

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -100,7 +100,7 @@ module.exports = ({ origin, insecure_origins = [], authorization = noop } = {}) 
       next()
     }
   }
-  function middleware (req, res) {
+  function middleware (req, res, next) {
     let u = url.parse(req.url, true)
 
 
@@ -147,7 +147,10 @@ module.exports = ({ origin, insecure_origins = [], authorization = noop } = {}) 
         res.setHeader('x-redirected-url', f.url)
       }
       f.body.pipe(res)
-    })
+    }).catch(e => {
+      console.error(e);
+      next();
+    });
   }
   const cors = microCors({
     allowHeaders,


### PR DESCRIPTION
If the Git URL is invalid, like `https://g`, the CORS Proxy currently crashes. This PR fixes it, and returns a 403 instead.