### PR TITLE
Update dockerfile to node 12, s/install/ci/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:8
+FROM node:12-alpine
 LABEL maintainer "William Hilton <wmhilton@gmail.com>"
 WORKDIR /srv
 COPY . .
-RUN npm install
+RUN npm ci
 EXPOSE 80
 ENV PORT=80
 CMD [ "npm", "start" ]


### PR DESCRIPTION
This introduces a relatively newer node version, as well as speeds up the build time by leveraging the lock-file to save users time (and bandwidth! us providers now meter this and charge for overage) when building this image.