### PR TITLE
fix: spawn `node` with the script in `start` so it works on Windows

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -87,10 +87,18 @@ switch (cmd) {
       }
     }
 
+    // Spawn `node <this script> run [...]` rather than `<this script> run`
+    // directly. Invoking the .js file as the executable relies on the
+    // `#!/usr/bin/env node` shebang and therefore only works on Unix-like
+    // shells; on Windows, .js files are not directly executable through
+    // CreateProcess and the spawn call fails. Using `process.execPath`
+    // (the currently-running `node` binary) is portable across platforms.
+    // `windowsHide: true` prevents the detached child from flashing a
+    // console window on Windows.
     const daemon = spawn(
-      import.meta.filename,
-      ['run', port && `--port=${port}`].filter((a) => a),
-      { stdio: 'ignore', detached: true },
+      process.execPath,
+      [import.meta.filename, 'run', port && `--port=${port}`].filter((a) => a),
+      { stdio: 'ignore', detached: true, windowsHide: true },
     );
     daemon.unref();
     console.log('Started CORS proxy daemon with PID', daemon.pid);


### PR DESCRIPTION
Goal: make cors-proxy microsoft-windows compatible.
Author: Claude. 
Notes: My own local machine is Ubuntu, I have not tested this, but it is fairly reasonable to expect it is correct.  It ought to  be tested.
Comments:  The `start` daemonizer used `spawn(import.meta.filename, ['run', ...])`, which relied on the `#!/usr/bin/env node` shebang at the top of bin.js to make the .js file directly executable. That works on Unix-like systems but not on Windows: `CreateProcess` cannot execute a `.js` file as a binary, so the spawn call fails and `cors-proxy start` silently breaks the daemon-launch step on Windows.

Spawn `process.execPath` (the currently-running `node` binary) and pass `import.meta.filename` as its first argument instead. This is the same end result on Unix-like systems and is portable to Windows.

Also pass `windowsHide: true` so the detached daemon doesn't flash a console window on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon startup for more reliable cross-platform behavior when launching background processes.
  * Prevented brief console window flashing on Windows during daemon initialization.
  * Adjusted daemon launch arguments to ensure consistent handling of optional port settings and reduce startup failures across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->